### PR TITLE
Check for valid token ids to maintain compliance with `IERC5643` documentation

### DIFF
--- a/src/ERC5643.sol
+++ b/src/ERC5643.sol
@@ -37,7 +37,7 @@ contract ERC5643 is ERC721, IERC5643 {
         if (duration < minimumRenewalDuration) {
             revert RenewalTooShort();
         } else if (
-            maximumRenewalDuration > 0 && duration > maximumRenewalDuration
+            maximumRenewalDuration != 0 && duration > maximumRenewalDuration
         ) {
             revert RenewalTooLong();
         }

--- a/src/ERC5643.sol
+++ b/src/ERC5643.sol
@@ -131,6 +131,9 @@ contract ERC5643 is ERC721, IERC5643 {
         virtual
         returns (bool)
     {
+        if (!_exists(tokenId)) {
+            revert InvalidTokenId();
+        }
         return _isRenewable(tokenId);
     }
 
@@ -145,9 +148,6 @@ contract ERC5643 is ERC721, IERC5643 {
         virtual
         returns (bool)
     {
-        if (!_exists(tokenId)) {
-            revert InvalidTokenId();
-        }
         return true;
     }
 

--- a/src/ERC5643.sol
+++ b/src/ERC5643.sol
@@ -145,6 +145,9 @@ contract ERC5643 is ERC721, IERC5643 {
         virtual
         returns (bool)
     {
+        if (!_exists(tokenId)) {
+            revert InvalidTokenId();
+        }
         return true;
     }
 

--- a/src/ERC5643.sol
+++ b/src/ERC5643.sol
@@ -116,6 +116,9 @@ contract ERC5643 is ERC721, IERC5643 {
         virtual
         returns (uint64)
     {
+        if (!_exists(tokenId)) {
+            revert InvalidTokenId();
+        }
         return _expirations[tokenId];
     }
 

--- a/test/ERC5643Test.t.sol
+++ b/test/ERC5643Test.t.sol
@@ -106,6 +106,16 @@ contract ERC5643Test is Test {
         assertEq(erc5643.expiresAt(tokenId), 0);
     }
 
+    function testExpiresAtInvalidToken() public {
+        vm.expectRevert(InvalidTokenId.selector);
+        erc5643.expiresAt(100);
+    }
+
+    function testIsRenewableInvalidToken() public {
+        vm.expectRevert(InvalidTokenId.selector);
+        erc5643.isRenewable(100);
+    }
+
     function testExtendSubscriptionInvalidToken() public {
         vm.expectRevert(InvalidTokenId.selector);
         erc5643.extendSubscription(tokenId + 100, 30 days);

--- a/test/ERC5643Test.t.sol
+++ b/test/ERC5643Test.t.sol
@@ -108,12 +108,12 @@ contract ERC5643Test is Test {
 
     function testExpiresAtInvalidToken() public {
         vm.expectRevert(InvalidTokenId.selector);
-        erc5643.expiresAt(100);
+        erc5643.expiresAt(tokenId2);
     }
 
     function testIsRenewableInvalidToken() public {
         vm.expectRevert(InvalidTokenId.selector);
-        erc5643.isRenewable(100);
+        erc5643.isRenewable(tokenId2);
     }
 
     function testExtendSubscriptionInvalidToken() public {


### PR DESCRIPTION
Awesome standard and is very needed 👍. Really like the minimal design of `IERC5643`, my mind is already racing with extension ideas.

Here are some small updates to keep the `ERC5643` implementation compliant with the standard documentation.

Particularly `expiresAt` and `isRenewable` documentation call for: "Throws if `tokenId` is not a valid NFT" which is not checked in the current implementation.

Also update zero comparison to inequality which in theory is slightly cheaper, but in practice the compiler optimizes the difference away and it makes no difference. I still think inequality might be slightly more readable so I left it in.