### PR TITLE
Add case for renewSubscription process.

### DIFF
--- a/src/ERC5643.sol
+++ b/src/ERC5643.sol
@@ -65,7 +65,7 @@ contract ERC5643 is ERC721, IERC5643 {
 
         uint64 currentExpiration = _expirations[tokenId];
         uint64 newExpiration;
-        if (currentExpiration == 0) {
+        if ((currentExpiration == 0) || (currentExpiration < block.timestamp)) {
             newExpiration = uint64(block.timestamp) + duration;
         } else {
             if (!_isRenewable(tokenId)) {


### PR DESCRIPTION

### Description
In the renewing process, it can occur a duration time be less than the block.timestamp.
In that case, renewing the item can be used for less time than the user's payment duration.

### Tasks
Add condition for this case.
code: lines 68 (in ERC5643.sol)
