### PR TITLE
Gas optimize ERC5643

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ erc5643/=lib/ERC5643/
 Then you can import ERC5643 like so:
 
 ```solidity
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.19;
 
 import "erc5643/src/ERC5643.sol";
 

--- a/src/ERC5643.sol
+++ b/src/ERC5643.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.19;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "./IERC5643.sol";

--- a/src/IERC5643.sol
+++ b/src/IERC5643.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.19;
 
 interface IERC5643 {
     /// @notice Emitted when a subscription expiration changes

--- a/src/mocks/ERC5643Mock.sol
+++ b/src/mocks/ERC5643Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.19;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "../ERC5643.sol";

--- a/test/ERC5643Test.t.sol
+++ b/test/ERC5643Test.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.19;
 
 import "forge-std/Test.sol";
 import "../src/ERC5643.sol";


### PR DESCRIPTION
I have applied some optimizations on **repository-owned** code whilst keeping it readable:

### Changes
- Bump compiler version from `0.8.13` -> `0.8.19`, right before `PUSH0` opcode was introduced, thus allowing the usage of this base on _not fully EVM compliant_ chains.
- Replace solidity `revert` errors with their inline-assembly equivalence:
  - Declarations of errors were not removed to support recognition by other libraries.
- Emit `SubscriptionUpdate` logs and perform storage-related operations with inline-assembly.
- Perform other casting and comparisons with inline-assembly to further optimize checks.

All forge tests passed successfully, with these **before** and **after** gas costs:

- `testCancelNotOwner()`: from `17,836` to `17,800`
- `testCancelValid()`: from `20,777` to `20,723`
- `testExpiresAt()`: from `42,743` to `42,056`
- `testExpiresAtInvalidToken()`: from `12,901` to `12,865`
- `testExtendSubscriptionInvalidToken()`: from `13,039` to `12,991`
- `testIsRenewableInvalidToken()`: from `12,831` to `12,795`
- `testRenewalDurationTooLong()`: from `47,961` to `47,581`
- `testRenewalDurationTooShort()`: from `47,664` to `47,583`
- `testRenewalExistingSubscription()`: from `145,175` to `144,285`
- `testRenewalInsufficientPayment()`: from `26,874` to `26,650`
- `testRenewalInvalidTokenId()`: from `22,316` to `22,304`
- `testRenewalNewSubscription()`: from `53,103` to `52,702`
- `testRenewalNotOwner()`: from `17,961` to `17,913`

### Notes
- More optimizations would have been possible (e.g. using `STATICCALL`) at the cost of code readability.
- Further gas optimization suggestions would be relying on gas-efficient libraries such as [ERC721A](https://github.com/chiru-labs/ERC721A) for NFT allowance and existence checks.